### PR TITLE
EDIT/UPDATE example in this lesson use POST instead of PATCH

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,3 +35,22 @@ educational content. Everything from fixing typos, to correcting
 out-dated information, to improving exposition, to adding better examples,
 to fixing tests—all contributions to making the curriculum more effective are
 welcome.
+
+### New Contribution Details
+The EDIT/UPDATE action examaples in this lesson, which starts on line 254 in the README, are using the 'post/:id' route when I believe they should be using the conventional 'patch/:id' route. 
+
+I have changed the following lines the these files:
+
+README.md 
+    -line 265:
+        - added a hidden input field for Rack::MethodOverride (already included in config.ru) to use the PATCH request.
+    -line 295 and 333
+        -changed 'post/owners/:id' to 'patch/owners/:id'
+
+controllers/owners_controller.rb
+    -line 26 
+        -changed "post '/owners/:id' " to "patch '/owners:id' " to match RESTful route conventions
+
+controllers/pets_controller.rb
+    -line 22
+        -changed "post '/pets/:id' to "patch '/pets/:id' "

--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ Let's do it!
 <h1>Update Owner</h1>
 
 <form action="/owners/<%=@owner.id%>" method="POST">
+  <input id="hidden" type="hidden" name="_method" value="patch">  
   <label>Name:</label>
 
   <br></br>
@@ -291,7 +292,7 @@ Let's do it!
 
 The main difference here is that we added the `checked` property to each checkbox with a condition to test whether the given pet is already present in the current owner's collection of pets. We implemented this `if` statement by wrapping the `checked` attribute in ERB tags, allowing us to use Ruby on our view page.
 
-Go ahead and make some changes to your owner using this edit form, then place a `binding.pry` in your `post '/owners/:id'` action and submit the form. Once you hit your binding, type `params` in the terminal.
+Go ahead and make some changes to your owner using this edit form, then place a `binding.pry` in your `patch '/owners/:id'` action and submit the form. Once you hit your binding, type `params` in the terminal.
 
 I filled out my edit form like this:
 
@@ -329,7 +330,7 @@ Now, if we type `@owner.pets`, we'll see that the owner is no longer associated 
 Great! Now, we need to implement logic similar to that in our `post '/owners'` action to handle a user trying to associate a brand new pet to our owner:
 
 ```ruby
-post '/owners/:id' do
+patch '/owners/:id' do
   @owner = Owner.find(params[:id])
   @owner.update(params["owner"])
   if !params["pet"]["name"].empty?

--- a/app/controllers/owners_controller.rb
+++ b/app/controllers/owners_controller.rb
@@ -23,7 +23,7 @@ class OwnersController < ApplicationController
     erb :'/owners/show'
   end
 
-  post '/owners/:id' do 
+  patch '/owners/:id' do 
    
   end
 end

--- a/app/controllers/pets_controller.rb
+++ b/app/controllers/pets_controller.rb
@@ -19,7 +19,7 @@ class PetsController < ApplicationController
     erb :'/pets/show'
   end
 
-  post '/pets/:id' do 
+  patch '/pets/:id' do 
 
     redirect to "pets/#{@pet.id}"
   end


### PR DESCRIPTION
Hi! I believe conventional restful routes for the EDIT action use the HTTP verb 'PATCH' not 'POST'. Please read added documentation in Contributing.md for more details