### PR TITLE
updated sinatra version to prevent captures key in params hash

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,7 +44,7 @@ GEM
     mini_mime (1.0.0)
     mini_portile2 (2.3.0)
     minitest (5.11.3)
-    mustermann (1.0.2)
+    mustermann (1.0.3)
     nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
     pry (0.10.4)
@@ -55,7 +55,7 @@ GEM
       pry (>= 0.9.10, < 0.11.0)
     public_suffix (3.0.2)
     rack (2.0.5)
-    rack-protection (2.0.1)
+    rack-protection (2.0.4)
       rack
     rack-test (1.0.0)
       rack (>= 1.0, < 3)
@@ -84,10 +84,10 @@ GEM
     rspec-support (3.7.1)
     shotgun (0.9.2)
       rack (>= 1.0)
-    sinatra (2.0.1)
+    sinatra (2.0.4)
       mustermann (~> 1.0)
       rack (~> 2.0)
-      rack-protection (= 2.0.1)
+      rack-protection (= 2.0.4)
       tilt (~> 2.0)
     sinatra-activerecord (2.0.13)
       activerecord (>= 3.2)
@@ -131,4 +131,4 @@ DEPENDENCIES
   tux
 
 BUNDLED WITH
-   1.16.0
+   1.16.2


### PR DESCRIPTION
sinatra version was leading to an extra key called "captures" to be created in the params hash on post requests, so I updated the version to prevent this issue.